### PR TITLE
Define url resolver() when "resolve url" option is true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ module.exports = function(source) {
       });
     } else {
       styl.set(key, value);
+
+      if (key === 'resolve url' && value) {
+        styl.define('url', stylus.resolver());
+      }
     }
   });
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -27,4 +27,11 @@ describe("basic", function() {
 		(typeof css).should.be.eql("string");
 		css.should.match(/\url\(\"?img.png\"?\)/);
 	});
+	it("with option, should resolve urls relatively", function() {
+		var css = require(
+			"!raw-loader!../?{\"resolve url\":true}!./fixtures/shallow.styl"
+		);
+		(typeof css).should.be.eql("string");
+		css.should.match(/\url\(\"?img.png\"?\)/);
+	});
 });

--- a/test/fixtures/deep/deep-urls.styl
+++ b/test/fixtures/deep/deep-urls.styl
@@ -1,0 +1,2 @@
+.img
+  content url(../img.png)

--- a/test/fixtures/shallow.styl
+++ b/test/fixtures/shallow.styl
@@ -1,0 +1,1 @@
+@import 'deep/deep-urls';


### PR DESCRIPTION
`stylus.resolver()` resolves urls to the original stylus file they are defined in. This lets another stylus file import a later file which refers to a path relative the second path. This PR currently enables this when "resolve url" is true in the query options given to the loader.

As an example this could be a directory structure:

```
+ src/
  - index.styl
  + images/
    - logo.styl
    - logo.png
```

With that project hierarchy, say index.styl imports logo.styl, and logo.styl defines a class that has `content: url(./logo.png)`. Without `stylus.resolver()` building index.styl would result in `content: url(./logo.png)` and later webpack, through css-loader, builds in `src/logo.png` which doesn't exist. Instead with `stylus.resolver()` enabled, building index.styl results in `content: url(./images/logo.png)`, which webpack will successfully build with.

There is an included test that shows this working with the option stated in a `require(...)`. For a webpack configuration it could look like:

```
  module: {
    loaders: [
      { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader?{"resolve url":true}' }
    ]
  }
```

I chose "resolve url" as stylus's binary and tests set the option when they use stylus.resolver() ([test/run.js](https://github.com/LearnBoost/stylus/blob/16856bbcf4b6f054f840dbaf7e6ffcd45ae50c22/test/run.js#L27)). It could easily be changed to another name or capitalization.

For simple projects you could get around this issue in other ways, but for a project I'm on with @tkellen we have assets and their related styles placed in different repos without knowledge of each other. We can use `paths` to look up the style installed in `node_modules` or some other modules directory but need this to not end up with urls that know about the destination stylesheet and look like `url(../../node_modules/assets/images/foo.png)`. Instead the working url with `resolve url` enabled would be `url(../images/foo.png)`.
