### PR TITLE
allow configuration of stylus plugins inside the webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ will let you have an `index.styl` file in your styles package and `require('styl
 
 Be careful though not to use the extensions configuration for two types of in one folder. If a folder has a `index.js` and a `index.styl` and you `@import './that-folder'`, it'll end up importing a javascript file into your stylus.
 
+### Stylus Plugins
+
+You can also use stylus plugins by adding an extra `stylus` section to your `webpack.config.js`.
+
+```js
+var stylus_plugin = require('stylus_plugin');
+module: {
+  loaders: [
+    { test: /\.styl$/, loader: 'style-loader!css-loader!stylus-loader' }
+  ]
+},
+stylus: {
+  use: [stylus_plugin()]
+}
+```
+
 ## Install
 
 `npm install stylus-loader --save-dev`

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = function(source) {
   options.filename = options.filename || this.resourcePath;
   options.Evaluator = CachedPathEvaluator;
 
+  var stylusOptions = this.options.stylus || {};
+  options.use = options.use || stylusOptions.use || [];
+
   var styl = stylus(source, options);
   var paths = [path.dirname(options.filename)];
 
@@ -31,9 +34,11 @@ module.exports = function(source) {
   Object.keys(options).forEach(function(key) {
     var value = options[key];
     if (key === 'use') {
-      needsArray(value).forEach(function(func) {
-        if (typeof func === 'function') {
-          styl.use(func());
+      needsArray(value).forEach(function(plugin) {
+        if (typeof plugin === 'function') {
+          styl.use(plugin);
+        } else {
+          throw new Error("Plugin should be a function");
         }
       });
     } else if (key === 'define') {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -82,4 +82,9 @@ describe("basic", function() {
 		(typeof css).should.be.eql("string");
 		css.should.not.match(/\.imported-css/);
 	});
+	it("should allow stylus plugins to be configured in webpack.config.js", function() {
+		var css = require("!raw-loader!../!./fixtures/webpack.config-plugin.styl");
+		(typeof css).should.be.eql("string");
+		css.should.match(/width:\s?75%;/);
+	});
 });

--- a/test/fixtures/webpack.config-plugin.styl
+++ b/test/fixtures/webpack.config-plugin.styl
@@ -1,0 +1,3 @@
+body
+  width add(50%, 50%)
+

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -1,8 +1,19 @@
 // Just run "webpack-dev-server"
+function plugin() {
+  return function(style) {
+    style.define('add', function(a, b) {
+      return a.operate('+', b);
+    });
+  };
+}
+
 module.exports = {
 	context: __dirname,
 	entry: "mocha-loader!./all.js",
 	resolve: {
 		extensions: ["", ".js", ".css", ".styl"]
-	}
+	},
+  stylus: {
+    use: [plugin()]
+  }
 };


### PR DESCRIPTION
Addresses https://github.com/shama/stylus-loader/issues/4 .

Happy to get implementation feedback... there are a bunch of ways to go about this, but I went for reusing existing code and making the smallest change possible.  This does nothing but support `use` -- though you can see how it could easily be extended to support arbitrary stylus options.
