### PR TITLE
use ~ range for when

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "loader-utils": "~0.2.1",
     "nib": "~1.0.2",
     "stylus": "~0.42.2",
-    "when": "^3.1.0"
+    "when": "~3.2.x"
   },
   "devDependencies": {
     "webpack-dev-server": "~0.11.0",


### PR DESCRIPTION
I haven't explored what the issue might be between when `3.2.x` and `3.3.x`.  Just submitting this to keep things functioning until I get a response on #9.
