### PR TITLE
Updates stylus to 0.47.2

### DIFF
--- a/lib/evaluator.js
+++ b/lib/evaluator.js
@@ -141,7 +141,7 @@ CachedPathEvaluator.prototype.visitImport = function(imported) {
   if (!found) {
     found = utils.find(path, this.paths, this.filename);
     if (!found) {
-      found = this.lookupIndex(name);
+      found = utils.lookupIndex(name, this.paths, this.filename);
       index = true;
     }
   }

--- a/lib/pathcache.js
+++ b/lib/pathcache.js
@@ -98,7 +98,7 @@ function resolvers(options, webpackResolver) {
     function(context, path) {
       // Stylus calls the argument name. If it exists it should match the name
       // of a module in node_modules.
-      var found = evaluator.lookupIndex(path);
+      var found = utils.lookupIndex(path, options.paths, options.filename);
       if (found) {
         return {path: found, index: true};
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "loader-utils": "~0.2.1",
     "nib": "~1.0.2",
-    "stylus": "~0.42.2",
+    "stylus": "~0.47.2",
     "when": "~3.2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
This is needed to work with the v2.0 of axis-css.

https://github.com/jenius/axis/commit/386feb9f03495ffaf838f984e71303b1259266cb

Tests pass and ran it locally on my project and axis-css doesn't throw errors anymore.
